### PR TITLE
Use the default `virtualenvs.in-project` of the developer

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[virtualenvs]
-in-project = true


### PR DESCRIPTION
This PR removes the poetry.toml file that forces the

`virtualenvs.in-project = true`

setting for poetry.

For my local development, I prefer to respect the default setting on my machine, which is set to

`virtualenvs.in-project = null`

In that way, when I run poetry install, the virtual environment is created under `Users/peter_v/Library/Caches/pypoetry/virtualenvs`.

For the CI/CD (Github actions), it may be needed to have these files in a .venv in the working directory (also for the caching), but that is actually forced by this setting, if I understand correctly.

https://github.com/avsthiago/kopylot/blob/main/.github/actions/setup-poetry-env/action.yml#L21

So, if possible, I would prefer to not "force" the setting of virtualenvs.in-project = true on the developers and respect the default setting on their machine. But maybe there are other reasons why the current usage of virtualenvs.in-project = true is needed or is better.

Tested on command line and in PyCharm. I had to put the .python-version of https://github.com/avsthiago/kopylot/pull/3 temporarily in place to install a 3.11 version (that I prefer for this project).

```
➜  kopylot git:(use-default-virtualenvs.in-project) ✗ gst
On branch use-default-virtualenvs.in-project
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	deleted:    poetry.toml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.python-version

➜  kopylot git:(use-default-virtualenvs.in-project) ✗ poetry install
Creating virtualenv kopylot-1Dw6WV4w-py3.11 in /Users/peter_v/Library/Caches/pypoetry/virtualenvs
Installing dependencies from lock file

Package operations: 66 installs, 0 updates, 0 removals
...

Installing the current project: kopylot (0.0.4)

➜  kopylot git:(use-default-virtualenvs.in-project) ✗ poetry run pytest tests/
====================================== test session starts =======================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0
rootdir: /Users/peter_v/data/ai/git/github/petervandenabeele/kopylot
plugins: mock-3.10.0, cov-4.0.0
collected 12 items

tests/test_audit.py .....                                                                  [ 41%]
tests/test_chat.py ..                                                                      [ 58%]
tests/test_cli.py ...                                                                      [ 83%]
tests/test_ctl.py .                                                                        [ 91%]
tests/test_diagnose.py .                                                                   [100%]

======================================= 12 passed in 0.39s =======================================
```

Also tested a fresh load in PyCharm (forget the previously loaded interpreters first to avoid general confusion in PyCharm) and that works perfectly (shows "Poetry (kopylot) [Python 3.11.2]").

FYI, all tests are run on Mac M1, without using Docker.