### PR TITLE
All test commands (poetry, pytest, mypy) needed in allowlist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,10 @@ python =
     
 [testenv]
 passenv = PYTHON_VERSION
-allowlist_externals = poetry
+allowlist_externals =
+    poetry
+    pytest
+    mypy
 commands =
     poetry install -v
     pytest --doctest-modules tests --cov --cov-config=pyproject.toml --cov-report=xml


### PR DESCRIPTION
Ref. https://stackoverflow.com/a/47716994/2664134

This resolves the tox warnings about `pytest` and `mypy`

```
WARNING: test command found but not installed in testenv
  cmd: /Users/peter_v/Library/Caches/pypoetry/virtualenvs/kopylot-1Dw6WV4w-py3.11/bin/pytest
  env: /Users/peter_v/data/ai/git/github/petervandenabeele/kopylot/.tox/py311
Maybe you forgot to specify a dependency? See also the allowlist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
```

and

```
WARNING: test command found but not installed in testenv
  cmd: /Users/peter_v/Library/Caches/pypoetry/virtualenvs/kopylot-1Dw6WV4w-py3.11/bin/mypy
  env: /Users/peter_v/data/ai/git/github/petervandenabeele/kopylot/.tox/py311
Maybe you forgot to specify a dependency? See also the allowlist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
```