### PR TITLE
make install should not leave the terminal in the poetry shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ install: ## Install the poetry environment and install the pre-commit hooks
 	@echo "🚀 Creating virtual environment using pyenv and poetry"
 	@poetry install	
 	@poetry run pre-commit install
-	@poetry shell
 
 .PHONY: check
 check: ## Run code quality tools.


### PR DESCRIPTION
I think the make install should not leave the terminal in the poetry shell. All the other commands below that need a poetry have an actual `poetry run` there already. It was unexpected for me that `poetry install` put me inside the shell.

I tested all make commands (not the publish of course) with this line removed and it worked for me.

Also, this file had a missing newline at the end, probably due to a setting of the IDE of the developer that committed this file. I prefer to have newlines at the end of files, so that git does not complain (and black enforces that also for python files).

Later, I accidentally pushed a commit from another branch. I force pushed here to remove that commit again from this PR.